### PR TITLE
Fix dispatch/thunk for user login form

### DIFF
--- a/src/Components/LoginForm/LoginForm.js
+++ b/src/Components/LoginForm/LoginForm.js
@@ -4,6 +4,8 @@ import movie_time_logo from '../../images/movie_time.png'
 import { connect } from 'react-redux'
 import { postUserLogin } from '../../Thunks/postUserLogin'
 import { toggleModal } from '../../Actions'
+import { bindActionCreators } from 'redux';
+
 
 export class LoginForm extends React.Component {
   constructor() {
@@ -16,7 +18,7 @@ export class LoginForm extends React.Component {
 
   handleSubmit = (event) => {
     event.preventDefault();
-    postUserLogin(this.state)
+    this.props.postUserLogin(this.state)
     this.setState({
       email: "",
       password: ""
@@ -80,9 +82,9 @@ const mapStateToProps = ({ toggleModal }) => ({
   toggleModal
 })
 
-const mapDispatchToProps = dispatch => ({
-  toggleModal: bool => dispatch(toggleModal(bool))
-})
+const mapDispatchToProps = (dispatch) => (
+  bindActionCreators({ toggleModal, postUserLogin}, dispatch)
+)
 
 
 // export default connect(null, mapDispatchToProps)(LoginForm);


### PR DESCRIPTION
This PR will:
-import bindActionCreators from react-redux
-Change mapDispatchToProps method within the login form to utilize bindActionCreators
-Add postUserLogin to mapDispatchToProps login form
-Delete commented out export in login form
-Add 'this.props' to the invocation of postUserLogin within the login form